### PR TITLE
新增对飞书推送的支持 #21

### DIFF
--- a/hh-common/src/main/java/io/cruii/feign/BilibiliFeignService.java
+++ b/hh-common/src/main/java/io/cruii/feign/BilibiliFeignService.java
@@ -1,4 +1,4 @@
-package io.cruii.execution.feign;
+package io.cruii.feign;
 
 import io.cruii.pojo.vo.BiliTaskUserVO;
 import org.springframework.cloud.openfeign.FeignClient;

--- a/hh-common/src/main/java/io/cruii/feign/PushFeignService.java
+++ b/hh-common/src/main/java/io/cruii/feign/PushFeignService.java
@@ -1,9 +1,11 @@
-package io.cruii.execution.feign;
+package io.cruii.feign;
 
 import io.cruii.pojo.dto.PushMessageDTO;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
 
 /**
  * @author cruii
@@ -13,4 +15,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 public interface PushFeignService {
     @PostMapping()
     boolean push(@RequestBody PushMessageDTO message);
+
+    @PostMapping("expired")
+    boolean notifyExpired(@RequestBody List<String> expiredIdList);
 }

--- a/hh-common/src/main/java/io/cruii/pojo/entity/PushConfigDO.java
+++ b/hh-common/src/main/java/io/cruii/pojo/entity/PushConfigDO.java
@@ -17,7 +17,6 @@ public class PushConfigDO implements Serializable {
     private Long id;
 
     @TableId(type = IdType.INPUT)
-    @TableField(updateStrategy = FieldStrategy.IGNORED)
     private String dedeuserid;
 
     @TableField(updateStrategy = FieldStrategy.IGNORED)
@@ -43,4 +42,7 @@ public class PushConfigDO implements Serializable {
 
     @TableField(updateStrategy = FieldStrategy.IGNORED)
     private String barkDeviceKey;
+
+    @TableField(updateStrategy = FieldStrategy.IGNORED)
+    private String feiShuCustomBot;
 }

--- a/hh-common/src/main/java/io/cruii/task/DonateCoinTask.java
+++ b/hh-common/src/main/java/io/cruii/task/DonateCoinTask.java
@@ -27,12 +27,11 @@ public class DonateCoinTask extends VideoTask {
     public DonateCoinTask(BilibiliDelegate delegate) {
         super(delegate);
         this.config = delegate.getConfig();
-        Integer donateCoins = config.getDonateCoins();
-        log.info("配置投币数为：{}", donateCoins);
     }
 
     @Override
     public void run() {
+        log.info("配置投币数为：{}", config.getDonateCoins());
         // 防止全部都投过币而导致任务卡死
         counter++;
         if (counter > 3) {

--- a/hh-execution/src/main/java/io/cruii/execution/component/NettyClient.java
+++ b/hh-execution/src/main/java/io/cruii/execution/component/NettyClient.java
@@ -5,7 +5,7 @@ import cn.hutool.extra.spring.SpringUtil;
 import cn.hutool.json.JSONUtil;
 import io.cruii.exception.BilibiliCookieExpiredException;
 import io.cruii.execution.config.NettyConfiguration;
-import io.cruii.execution.feign.PushFeignService;
+import io.cruii.feign.PushFeignService;
 import io.cruii.model.BiliUser;
 import io.cruii.model.SpaceAccInfo;
 import io.cruii.pojo.dto.BiliTaskUserDTO;

--- a/hh-execution/src/main/java/io/cruii/execution/component/TaskExecutor.java
+++ b/hh-execution/src/main/java/io/cruii/execution/component/TaskExecutor.java
@@ -40,6 +40,10 @@ public class TaskExecutor {
     }
 
     public BiliTaskResult execute() {
+        log.info("当前版本: {}", "2.0.6");
+        log.info("更新日期: {}", "2023/03/09");
+        log.info("服务地址: {}", "https://ohmyhelper.com/bilibili");
+        log.info("项目源码: {}", "https://github.com/Cruii/oh-my-helper");
         log.info("------开始------");
         boolean expired = false;
         for (Task task : taskList) {

--- a/hh-push/src/main/java/io/cruii/push/controller/PushController.java
+++ b/hh-push/src/main/java/io/cruii/push/controller/PushController.java
@@ -5,6 +5,8 @@ import io.cruii.push.service.PushService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 /**
  * @author cruii
  * Created on 2022/4/6
@@ -22,5 +24,10 @@ public class PushController {
     @ResponseStatus(code = HttpStatus.CREATED)
     public boolean push(@RequestBody PushMessageDTO messageDTO) {
         return pushService.push(messageDTO);
+    }
+
+    @PostMapping("expired")
+    public void notifyExpired(@RequestBody List<String> expiredIdList) {
+        pushService.notifyExpired(expiredIdList);
     }
 }

--- a/hh-push/src/main/java/io/cruii/push/pusher/Pusher.java
+++ b/hh-push/src/main/java/io/cruii/push/pusher/Pusher.java
@@ -5,5 +5,7 @@ package io.cruii.push.pusher;
  * Created on 2021/9/23
  */
 public interface Pusher {
+    boolean notifyExpired(String id);
+
     boolean push(String content);
 }

--- a/hh-push/src/main/java/io/cruii/push/pusher/impl/BarkPusher.java
+++ b/hh-push/src/main/java/io/cruii/push/pusher/impl/BarkPusher.java
@@ -26,6 +26,11 @@ public class BarkPusher implements Pusher {
     }
 
     @Override
+    public boolean notifyExpired(String id) {
+        return push("账号[" + id + "]登录失败，请访问 https://ohmyhelper.com/bilibili/ 重新扫码登陆更新Cookie");
+    }
+
+    @Override
     public boolean push(String content) {
         JSONObject body = JSONUtil.createObj();
         body.set("body", content)

--- a/hh-push/src/main/java/io/cruii/push/pusher/impl/FeiShuCustomBotPusher.java
+++ b/hh-push/src/main/java/io/cruii/push/pusher/impl/FeiShuCustomBotPusher.java
@@ -1,0 +1,97 @@
+package io.cruii.push.pusher.impl;
+
+import cn.hutool.json.JSONArray;
+import cn.hutool.json.JSONObject;
+import cn.hutool.json.JSONUtil;
+import io.cruii.push.pusher.Pusher;
+import io.cruii.util.OkHttpUtil;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+public class FeiShuCustomBotPusher implements Pusher {
+    private final String feiShuCustomBot;
+
+    public FeiShuCustomBotPusher(String feiShuCustomBot) {
+        this.feiShuCustomBot = feiShuCustomBot;
+    }
+
+    @Override
+    public boolean notifyExpired(String id) {
+        JSONArray elements = JSONUtil.createArray()
+                .set(JSONUtil.createObj().set("tag", "div")
+                        .set("text", JSONUtil.createObj()
+                                .set("tag", "lark_md")
+                                .set("content", "账号[" + id + "]登录失败，请访问 https://ohmyhelper.com/bilibili/ 重新扫码登陆更新Cookie"))
+                        .set("extra", JSONUtil.createObj()
+                                .set("tag", "button")
+                                .set("text", JSONUtil.createObj()
+                                        .set("tag", "lark_md")
+                                        .set("content", "立即登录"))
+                                .set("type", "primary")
+                                .set("multi_url", JSONUtil.createObj()
+                                        .set("url", "https://ohmyhelper.com/login")
+                                        .set("pc_url", "")
+                                        .set("android_url", "")
+                                        .set("ios_url", ""))));
+        JSONObject cardLink = JSONUtil.createObj().set("url", "")
+                .set("pc_url", "")
+                .set("android_url", "")
+                .set("ios_url", "");
+        return push0(elements, cardLink);
+    }
+
+    @Override
+    public boolean push(String content) {
+        JSONArray elements = JSONUtil.createArray()
+                .set(JSONUtil.createObj().set("tag", "div")
+                        .set("text", JSONUtil.createObj()
+                                .set("tag", "lark_md")
+                                .set("content", content)));
+        JSONObject cardLink = JSONUtil.createObj().set("url", "")
+                .set("pc_url", "")
+                .set("android_url", "")
+                .set("ios_url", "");
+        return push0(elements, cardLink);
+    }
+
+    private boolean push0(JSONArray elements, JSONObject cardLink) {
+        JSONObject config = JSONUtil.createObj().set("wide_screen_mode", true);
+        JSONObject header = JSONUtil.createObj().set("template", "yellow")
+                .set("title", JSONUtil.createObj().set("tag", "plain_text").set("content", "OH MY HELPER 消息推送"));
+
+        JSONObject card = JSONUtil.createObj()
+                .set("config", config)
+                .set("header", header)
+                .set("elements", elements)
+                .set("card_link", cardLink);
+
+        JSONObject requestBody = JSONUtil.createObj();
+        requestBody.set("msg_type", "interactive")
+                .set("card", card);
+
+        Request request = new Request.Builder()
+                .url(feiShuCustomBot)
+                .post(RequestBody.create(requestBody.toJSONString(0).getBytes(StandardCharsets.UTF_8),
+                        MediaType.parse("application/json")))
+                .build();
+
+        try (Response response = OkHttpUtil.executeWithRetry(request, false)) {
+            if (response.isSuccessful()) {
+                log.info("飞书自定义机器人推送成功");
+                return true;
+            } else {
+                log.error("飞书自定义机器人推送失败: {}", response.body().string());
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return false;
+    }
+}

--- a/hh-push/src/main/java/io/cruii/push/pusher/impl/QyWechatPusher.java
+++ b/hh-push/src/main/java/io/cruii/push/pusher/impl/QyWechatPusher.java
@@ -30,6 +30,11 @@ public class QyWechatPusher implements Pusher {
     }
 
     @Override
+    public boolean notifyExpired(String id) {
+        return push("账号[" + id + "]登录失败，请访问 https://ohmyhelper.com/bilibili/ 重新扫码登陆更新Cookie");
+    }
+
+    @Override
     public boolean push(String content) {
         JSONObject requestBody = JSONUtil.createObj();
         requestBody.set("touser", "@all")

--- a/hh-push/src/main/java/io/cruii/push/pusher/impl/ServerChanPusher.java
+++ b/hh-push/src/main/java/io/cruii/push/pusher/impl/ServerChanPusher.java
@@ -29,6 +29,11 @@ public class ServerChanPusher implements Pusher {
     }
 
     @Override
+    public boolean notifyExpired(String id) {
+        return push("账号[" + id + "]登录失败，请访问 https://ohmyhelper.com/bilibili/ 重新扫码登陆更新Cookie");
+    }
+
+    @Override
     public boolean push(String content) {
         URI uri = HttpUtil.buildUri("https://sctapi.ftqq.com/" + scKey + ".send");
         List<NameValuePair> formData = new ArrayList<>();

--- a/hh-push/src/main/java/io/cruii/push/pusher/impl/TelegramBotPusher.java
+++ b/hh-push/src/main/java/io/cruii/push/pusher/impl/TelegramBotPusher.java
@@ -32,6 +32,11 @@ public class TelegramBotPusher implements Pusher {
     }
 
     @Override
+    public boolean notifyExpired(String id) {
+        return push("账号[" + id + "]登录失败，请访问 https://ohmyhelper.com/bilibili/ 重新扫码登陆更新Cookie");
+    }
+
+    @Override
     public boolean push(String content) {
         URI uri = HttpUtil.buildUri("https://api.telegram.org/bot" + token + "/sendMessage");
         List<NameValuePair> formData = new ArrayList<>();

--- a/hh-push/src/main/java/io/cruii/push/service/PushService.java
+++ b/hh-push/src/main/java/io/cruii/push/service/PushService.java
@@ -2,10 +2,14 @@ package io.cruii.push.service;
 
 import io.cruii.pojo.dto.PushMessageDTO;
 
+import java.util.List;
+
 /**
  * @author cruii
  * Created on 2022/4/6
  */
 public interface PushService {
     boolean push(PushMessageDTO messageDTO);
+
+    void notifyExpired(List<String> idList);
 }


### PR DESCRIPTION
:new: 新增对飞书推送的支持，并支持若cookie过期可在飞书内点击按钮跳转登录界面进行扫码。新增专门用于推送过期消息的方法，为后续各个推送渠道进行自定义的过期消息推送做准备
:loud_sound: 更新日志
:new: 新增每天的过期消息推送，并修改日常任务执行时间，暂时调整为每天早上9点到晚上11点